### PR TITLE
Change of admin email address.

### DIFF
--- a/liquid/settings.py
+++ b/liquid/settings.py
@@ -9,7 +9,7 @@ DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
-     ('ACM Admins', 'admin@acm.uiuc.edu'),
+     ('Liquid Admins', 'liquid@acm.uiuc.edu'),
 )
 
 MANAGERS = ADMINS


### PR DESCRIPTION
Nathan has set up an alias of liquid@acm.uiuc.edu to receive error emails, which currently point to @reedlabots and admin@acm.uiuc.edu.  I've changed that in the Liquid settings.
