### PR TITLE
Send weekly jobs email to correct address

### DIFF
--- a/liquid/scripts/send_job_email.py
+++ b/liquid/scripts/send_job_email.py
@@ -37,7 +37,7 @@ if jobs:
 
 
    try:
-      send_mail('ACM@UIUC Weekly Job Postings', email, 'ACM Corporate Committee <corporate@acm.uiuc.edu>',['reedlabotz@gmail.com'], fail_silently=False)
+      send_mail('ACM@UIUC Weekly Job Postings', email, 'ACM Corporate Committee <corporate@acm.uiuc.edu>',['jobs-l@acm.uiuc.edu'], fail_silently=False)
       print "Email sent"
       for j in jobs:
          j.sent = True


### PR DESCRIPTION
Weekly jobs email will now go to jobs-l instead of to Reed
