### PR TITLE
Changed Illinois I logo to link to illinois.edu instead of acm.uiuc.edu

### DIFF
--- a/liquid/templates/base.html
+++ b/liquid/templates/base.html
@@ -37,7 +37,7 @@
       <div class="header">
         <div class="header_bar">
           <img src="/static/img/ilogo.png" class="ilogo">
-          <a class="brand" href="/">
+          <a class="brand" href="http://illinois.edu/">
             <img src="/static/img/logo.png" width="150" height="150" class="logo">
             <div>
               <strong>Association for Computing Machinery</strong><br>


### PR DESCRIPTION
TODO: Close Kurtis' issue about this.

Ace
