### PR TITLE
Fixed reference to a nonexistent directory in the command to change ldap pass

### DIFF
--- a/liquid/templates/registration/login.html
+++ b/liquid/templates/registration/login.html
@@ -18,7 +18,7 @@
   <p>Your username is your netid. Your password is your LDAP password.</p>
   
   <p>Don't have an LDAP password? Run this from a Linux cluster machine: 
-  <code>/afs/acm.illinois.edu/admin/scripts/set-ldap-password</code> </p>
+  <code>/afs/acm.uiuc.edu/admin/scripts/set-ldap-password</code> </p>
   
   <p>Don't have a cluster account? Email <a href="mailto:admin@acm.illinois.edu">admin@acm.illinois.edu</a></p>
 </div>


### PR DESCRIPTION
Sorry, still cleaning up from the regex that replaced every single instance of uiuc.  Lesson learned.
