### PR TITLE
Make login page text more helpful

### DIFF
--- a/liquid/templates/registration/login.html
+++ b/liquid/templates/registration/login.html
@@ -15,7 +15,8 @@
   </form>
 </div>
 <div class="span6">
-  <p>Your username is your netid. Your password is your Campus Active Directory password.</p>
+  <p>Your username is your NetID. Your password is your Campus Active Directory password.</p>
+  <p>You must be an ACM Member to log into the Intranet.</p>
 </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Added a statement saying that you need to be a member to log in, since non-member logins will fail.
