### PR TITLE
Update Caffeine link to a working one.

### DIFF
--- a/liquid/templates/intranet/base.html
+++ b/liquid/templates/intranet/base.html
@@ -14,7 +14,7 @@
               <a href="https://www-s.acm.uiuc.edu/mailman/listinfo">Mailing Lists</a>
             </li>
             <li>
-              <a href="http://www.acm.uiuc.edu/caffeine/">Caffeine</a>
+              <a href="https://www-s.acm.uiuc.edu/caffeine">Caffeine</a>
             </li> 
             <li>
               <a href="http://amp.acm.uiuc.edu">Acoustics</a>


### PR DESCRIPTION
Old Caffeine link was broken and not using https:// -- fixed this.
