### PR TITLE
main page: fix bounds error on events widget

### DIFF
--- a/liquid/views.py
+++ b/liquid/views.py
@@ -7,8 +7,11 @@ import datetime
 from intranet.models import Event
 
 def main(request):
-   next_seven_days = datetime.date.today() + datetime.timedelta(days=5)
-   events = Event.objects.filter(endtime__gte=datetime.date.today(),starttime__lte=next_seven_days).order_by('starttime')
+   next_five_days = datetime.date.today() + datetime.timedelta(days=5)
+   events = Event.objects.filter(
+      endtime__gte=datetime.date.today(),
+      starttime__lt=next_five_days
+   ).order_by('starttime')
 
    event_days = []
    for i in range(5):
@@ -21,10 +24,10 @@ def main(request):
       event_days[event_offset]['events'].append(e)
 
    return render_to_response('main.html',{"event_days":event_days,"events":events},context_instance=RequestContext(request))
-	
+
 def contact(request):
    return render_to_response('contact.html',{"section":"contact"},context_instance=RequestContext(request))
-  
+
 def conference(request):
    return render_to_response('conf.html',{"section":"conference"},context_instance=RequestContext(request))
 


### PR DESCRIPTION
The issue was that we were searching for events that were less than or
equal to (now + 5 days). Normally this was never an issue, but we
happened to have an event this week starting at exactly 12:00am five
days in the future, so it didn't fit in the array. A simple change of
"lte" to "lt" fixes it.

I also fixed a typo where now + 5 days was called `next_seven_days`.

cc @CJS7070 @ClareCat
