### PR TITLE
member_database: remove `@` from email from name

### DIFF
--- a/liquid/intranet/member_database/views.py
+++ b/liquid/intranet/member_database/views.py
@@ -94,7 +94,7 @@ ACM@UIUC
 
 
 Approved by: %s"""%(u.first_name,u.last_name,u.date_joined.strftime("%a %b %d, %Y %H:%M:%S"),request.user.username)
-      send_mail('Welcome to ACM@UIUC', welcome_msg, 'ACM@UIUC <acm@acm.illinois.edu>',[u.email,'payment-mailer@acm.illinois.edu'], fail_silently=False)
+      send_mail('Welcome to ACM@UIUC', welcome_msg, 'ACM at UIUC <acm@acm.illinois.edu>',[u.email,'payment-mailer@acm.illinois.edu'], fail_silently=False)
       return HttpResponseRedirect('/intranet/members/search?q=%s' % u.username) # Redirect after POST
    except ValueError:
       messages.add_message(request, messages.ERROR, "Not a valid netid")


### PR DESCRIPTION
Apparently some servers will read that as the email address instead of the name if it has an at symbol.