### PR TITLE
Dockerfile: fix build to remove pyc files, mv local_settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,10 @@ ADD docker /liquid
 ADD liquid /liquid/app
 
 WORKDIR /liquid
+RUN find . -name "*.pyc" -delete
 
-RUN cp wsgi.py app/wsgi.py
-RUN cp local_settings.py app/local_settings.py
+RUN mv wsgi.py app/wsgi.py
+RUN mv local_settings.py app/local_settings.py
 RUN pip install -r app/requirements.txt
 
 RUN python app/manage.py syncdb --noinput


### PR DESCRIPTION
This fixes the resume book, which has been broken since we moved to our
new liquid hosts. The problem is a rather subtle confusion of *.pyc
files and import paths. This fixes the problem by clearing all *.pyc
files, which we don't want anyways, as well as moving an excess
`local_settings.py` file out of the import path.