### PR TITLE
Hotfix for sponsorship logo sizing

### DIFF
--- a/liquid/static/css/sponsors.css
+++ b/liquid/static/css/sponsors.css
@@ -1,5 +1,6 @@
 .company-card {
   width: 23%;
+  height: 36%;
   margin: 5px;
   background: #fff;
   padding: 10px;
@@ -10,3 +11,8 @@
 	opacity: 1;
 }
 
+.company-card img {
+  margin: 0 auto;
+  display: block;
+  max-height: 100%;
+}


### PR DESCRIPTION
Fixes sponsorship logos being sized funnily. (Not a complete fix, since that requires understanding more about and/or refactoring out the JS grid system we're using for that page.)