### PR TITLE
Remove admin names from contact page since they change so frequently …

### DIFF
--- a/liquid/templates/contact.html
+++ b/liquid/templates/contact.html
@@ -27,14 +27,6 @@
     </p>
     
     <p><strong>System Administrators</strong><br>
-       Calvin Shirley,
-       Nathan Handler,
-       Adam Madsen,
-       Eric Sauer,
-       Milan Dasgupta,
-       Jake Bailey,
-       Sam Fu,
-       Luke Liu
        <br>
        <a href="mailto:admin@acm.illinois.edu">admin@acm.illinois.edu</a>
      </p>

--- a/liquid/templates/contact.html
+++ b/liquid/templates/contact.html
@@ -27,7 +27,6 @@
     </p>
     
     <p><strong>System Administrators</strong><br>
-       <br>
        <a href="mailto:admin@acm.illinois.edu">admin@acm.illinois.edu</a>
      </p>
 


### PR DESCRIPTION
…and are always outdated. And to remove my name since I'm still getting communications directly because of this page.