### PR TITLE
Fix Add to Google Calendar link not working

### DIFF
--- a/liquid/templates/cal/main.html
+++ b/liquid/templates/cal/main.html
@@ -2,7 +2,7 @@
 {% block content %}
 
 <header class="page-header">
-<a href="http://www.google.com/calendar/render?cid=http%3A%2F%2Facm.uiuc.edu%2Fcalendar%2Ffeed.ics" target="_blank" class="pull-right btn btn-primary">Add to Google Calendar</a><h1>Calendar</h1>
+<a href="http://www.google.com/calendar/render?cid=http%3A%2F%2Facm.illinois.edu%2Fcalendar%2Ffeed.ics" target="_blank" class="pull-right btn btn-primary">Add to Google Calendar</a><h1>Calendar</h1>
 
 {% include "cal/make_calendar_template.html" %}
 


### PR DESCRIPTION
Tested in my browser using Inspect Element (but admittedly not locally)

@sskhandek This should be a fairly small change, but a ship-it would still be nice. :smile: