### PR TITLE
Add a "vend" button to the Caffeine Manager

### DIFF
--- a/liquid/intranet/caffeine_manager/soda/views.py
+++ b/liquid/intranet/caffeine_manager/soda/views.py
@@ -49,7 +49,7 @@ def add(request):
         soda_form=SodaForm(request.POST)
         if soda_form.is_valid():
             soda_form.save()
-            return redirect(reverse('cm_soda_all_sodas'))
+            return redirect(reverse('cm_soda_allsodas'))
     else:
         soda_form=SodaForm()
 

--- a/liquid/intranet/caffeine_manager/trays/urls.py
+++ b/liquid/intranet/caffeine_manager/trays/urls.py
@@ -6,4 +6,5 @@ urlpatterns=patterns('',
     url(r'^edit/(?P<trayId>\d+)/$', 'intranet.caffeine_manager.trays.views.edit_tray', name='cm_trays_edit'),
     url(r'^delete/(?P<trayId>\d+)/$', 'intranet.caffeine_manager.trays.views.delete_tray', name='cm_trays_delete'),
     url(r'^forcevend/(?P<trayId>\d+)/$', 'intranet.caffeine_manager.trays.views.force_vend', name='cm_trays_forcevend'),
+    url(r'^buyvend/(?P<trayId>\d+)/$', 'intranet.caffeine_manager.trays.views.buy_vend', name='cm_trays_buy_vend'),
 )

--- a/liquid/intranet/caffeine_manager/urls.py
+++ b/liquid/intranet/caffeine_manager/urls.py
@@ -3,7 +3,7 @@ from django.views.generic.simple import redirect_to
 from intranet.caffeine_manager.views import leaderboard
 
 urlpatterns=patterns('',
-    url(r'^$', redirect_to, {'url': '/intranet/caffeine/soda'}, name='cm_soda_all_sodas'),
+    url(r'^$', redirect_to, {'url': '/intranet/caffeine/trays'}),
     url(r'^stats/$', leaderboard, name='cm_stats'),
 
     url(r'^user/', include('intranet.caffeine_manager.user.urls')),

--- a/liquid/intranet/migrations/0015_add_field_vending_last_vend.py
+++ b/liquid/intranet/migrations/0015_add_field_vending_last_vend.py
@@ -1,0 +1,216 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'Vending.last_vend'
+        db.add_column('vending', 'last_vend', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, default=datetime.datetime(2016, 3, 8, 21, 3, 21, 854314), blank=True), keep_default=False)
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'Vending.last_vend'
+        db.delete_column('vending', 'last_vend')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2016, 3, 8, 21, 3, 21, 860434)'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2016, 3, 8, 21, 3, 21, 860364)'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'django_mailman.list': {
+            'Meta': {'object_name': 'List'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subscribers': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.User']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'intranet.event': {
+            'Meta': {'object_name': 'Event'},
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['intranet.Member']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'endtime': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sponsors': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['intranet.Group']", 'null': 'True', 'blank': 'True'}),
+            'starttime': ('django.db.models.fields.DateTimeField', [], {}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'g'", 'max_length': '1'})
+        },
+        'intranet.group': {
+            'Meta': {'object_name': 'Group'},
+            'date_formed': ('django.db.models.fields.DateField', [], {}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'mailing_list': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['django_mailman.List']"}),
+            'meeting_day': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'meeting_location': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'meeting_time': ('django.db.models.fields.TimeField', [], {'null': 'True', 'blank': 'True'}),
+            'members': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['intranet.Member']", 'symmetrical': 'False', 'through': "orm['intranet.GroupMember']", 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'active'", 'max_length': '255'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        'intranet.groupmember': {
+            'Meta': {'unique_together': "(('group', 'member'),)", 'object_name': 'GroupMember'},
+            'date_joined': ('django.db.models.fields.DateField', [], {'default': 'datetime.date.today'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'membership'", 'to': "orm['intranet.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_chair': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'member': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['intranet.Member']"}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'active'", 'max_length': '255'})
+        },
+        'intranet.job': {
+            'Meta': {'object_name': 'Job'},
+            'company': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'contact_email': ('django.db.models.fields.EmailField', [], {'max_length': '255'}),
+            'contact_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'contact_phone': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'job_title': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sent': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'defer'", 'max_length': '10'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'type_full': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'type_intern': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'type_part': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'intranet.member': {
+            'Meta': {'object_name': 'Member', '_ormbases': ['auth.User']},
+            'left_uiuc': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'active'", 'max_length': '255'}),
+            'uin': ('django.db.models.fields.CharField', [], {'max_length': '9', 'null': 'True'}),
+            'user_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'intranet.premember': {
+            'Meta': {'object_name': 'PreMember'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'netid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '16'}),
+            'uin': ('django.db.models.fields.CharField', [], {'max_length': '9'})
+        },
+        'intranet.preresumeperson': {
+            'Meta': {'object_name': 'PreResumePerson', '_ormbases': ['intranet.ResumePerson']},
+            'number': ('django.db.models.fields.IntegerField', [], {}),
+            'resumeperson_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['intranet.ResumePerson']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'intranet.recruiter': {
+            'Meta': {'object_name': 'Recruiter', '_ormbases': ['auth.User']},
+            'expires': ('django.db.models.fields.DateField', [], {}),
+            'level': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'logo': ('utils.fields.ContentTypeRestrictedFileField', [], {'max_length': '100', 'null': 'True'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True'}),
+            'user_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'intranet.resume': {
+            'Meta': {'object_name': 'Resume'},
+            'approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['intranet.ResumePerson']", 'null': 'True'}),
+            'resume': ('utils.fields.ContentTypeRestrictedFileField', [], {'max_length': '100'})
+        },
+        'intranet.resumedownload': {
+            'Meta': {'object_name': 'ResumeDownload'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'set': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['intranet.ResumeDownloadSet']"})
+        },
+        'intranet.resumedownloadset': {
+            'Meta': {'object_name': 'ResumeDownloadSet'},
+            'acm': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'graduation_end': ('django.db.models.fields.DateField', [], {'null': 'True'}),
+            'graduation_start': ('django.db.models.fields.DateField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'level': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'seeking': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'})
+        },
+        'intranet.resumeperson': {
+            'Meta': {'object_name': 'ResumePerson'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'graduation': ('django.db.models.fields.DateField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'ldap_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'level': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'netid': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'resume_reminded_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2016, 3, 8, 21, 3, 14, 946991)'}),
+            'resume_reminder_subscribed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'resume_uuid': ('django.db.models.fields.CharField', [], {'default': "'ebb94e88-abc1-4dd5-b739-11b3502b6c5b'", 'max_length': '255'}),
+            'seeking': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'intranet.vending': {
+            'Meta': {'object_name': 'Vending', 'db_table': "'vending'"},
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': '0', 'max_digits': '10', 'decimal_places': '2'}),
+            'caffeine': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'calories': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '11'}),
+            'last_vend': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'sodas': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '11'}),
+            'spent': ('django.db.models.fields.DecimalField', [], {'default': '0', 'max_digits': '10', 'decimal_places': '2'}),
+            'uid': ('django.db.models.fields.IntegerField', [], {'max_length': '11', 'primary_key': 'True'})
+        },
+        'intranet.vendingvoter': {
+            'Meta': {'object_name': 'VendingVoter', 'db_table': "'vending_voters'"},
+            'uid': ('django.db.models.fields.IntegerField', [], {'max_length': '11', 'primary_key': 'True'}),
+            'votes': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['soda.Soda']", 'symmetrical': 'False'})
+        },
+        'soda.soda': {
+            'Meta': {'object_name': 'Soda', 'db_table': "'sodas'"},
+            'base_price': ('django.db.models.fields.DecimalField', [], {'default': '0.5', 'max_digits': '10', 'decimal_places': '2'}),
+            'caffeine': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'calories': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '11'}),
+            'cost': ('django.db.models.fields.DecimalField', [], {'default': '0.5', 'max_digits': '10', 'decimal_places': '2'}),
+            'dispensed': ('django.db.models.fields.IntegerField', [], {'default': '0', 'max_length': '11'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True', 'db_column': "'sid'"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        }
+    }
+
+    complete_apps = ['intranet']

--- a/liquid/intranet/models.py
+++ b/liquid/intranet/models.py
@@ -121,6 +121,7 @@ class Vending(models.Model):
    caffeine = models.FloatField(default=0)
    spent = models.DecimalField(max_digits=10, decimal_places=2,default=0)
    sodas = models.IntegerField(max_length=11,default=0)
+   last_vend = models.DateTimeField(auto_now_add=True)
 
    @property
    def user(self):

--- a/liquid/templates/intranet/caffeine_manager/list_page.html
+++ b/liquid/templates/intranet/caffeine_manager/list_page.html
@@ -3,11 +3,11 @@
 {% block intranet_content %}
     <h2>Caffeine Manager</h2>
     <ul class="nav nav-tabs">
-      <li{% if sub_page == "sodas" %} class="active"{% endif %}>
-        <a href="{% url cm_soda_allsodas %}">Sodas</a>
-      </li>
       <li{% if sub_page == "trays" %} class="active"{% endif %}>
         <a href="{% url cm_trays_view %}">Trays</a>
+      </li>
+      <li{% if sub_page == "sodas" %} class="active"{% endif %}>
+        <a href="{% url cm_soda_allsodas %}">Sodas</a>
       </li>
       <li{% if sub_page == "leaderboard" %} class="active"{% endif %}>
         <a href="{% url cm_stats %}">Leaderboard</a>

--- a/liquid/templates/intranet/caffeine_manager/trays/trays.html
+++ b/liquid/templates/intranet/caffeine_manager/trays/trays.html
@@ -14,8 +14,8 @@
         {% if is_caffeine_admin %}
             <th>Enabled</th>
             <th>Detect Override</th>
-            <th>Actions</th>
         {% endif %}
+        <th>Actions</th>
     </tr>
 
     {% for t in trays %}
@@ -31,8 +31,13 @@
                 <a class="btn btn-small btn-primary" href='{% url cm_trays_edit t.id %}'>Edit Tray</a>
                 {% if t.soda %}
                     <a class="btn btn-small" href='{% url cm_soda_edit t.soda.id %}'>Edit Soda</a>
+                    <a class="btn btn-small btn-success" href='{% url cm_trays_buy_vend t.id %}'>Vend</a>
                     <a class="btn btn-small btn-danger" href='{% url cm_trays_forcevend t.id %}'>Force Vend</a>
                 {% endif %}
+            </td>
+        {% else %}
+            <td>
+                <a class="btn btn-small btn-success" href='{% url cm_trays_buy_vend t.id %}'>Vend</a>
             </td>
         {% endif %}
     </tr>


### PR DESCRIPTION
Allows people to vend sodas from Liquid, since the card reader is broken.

In the future, we should also add either a mobile app and/or Slackbot integration - but maybe that's something for once Groot's done.

@rohankapoorcom Unless I can modify the DB myself, you'll need to run the following command on the DB once this is pushed (to add the **last_vend** column to the **vending** table):

`alter table vending add column last_vend datetime; update vending set last_vend = CURDATE();`

@sskhandek @rohankapoorcom Mind looking over this, and signing off if it looks good?